### PR TITLE
Add filter functionality to scanBoards and listPorts method

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -80,7 +80,7 @@ function scanBoards(options){
 
   return this.releaseAllBoards()
     .then(function(){
-      self._devices = [];
+      self._devices = {};
       return self.listPorts(options);
     })
     .then(function(ports){

--- a/lib/board.js
+++ b/lib/board.js
@@ -23,14 +23,21 @@ function removeBoard(type){
 }
 
 function listPorts(options){
-  var blacklist = _.get(options, 'blacklist') || [];
+  var reject = _.get(options, 'reject') || [];
+  var predicate = reject;
+  if(Array.isArray(reject)){
+    predicate = function(port){
+      return _.some(reject, function(entry){
+        if(typeof entry === 'string'){
+          return port.comName === entry;
+        }
+        return entry.test(port.comName);
+      });
+    };
+  }
   return nodefn.call(Serialport.list)
     .then(function(portList){
-      return _.reject(portList, function(port){
-        return _.some(blacklist, function(black){
-          return black.test(port.comName);
-        });
-      });
+      return _.reject(portList, predicate);
     });
 }
 

--- a/lib/board.js
+++ b/lib/board.js
@@ -105,16 +105,14 @@ function scanBoards(options){
 }
 
 function getOpenBoards(){
-  return _.filter(_.values(this._devices), function(device){
+  return _.filter(this._devices, function(device){
     return device.isOpen();
   });
 }
 
 function releaseAllBoards(){
-  var closingDevices = _.map(_.values(this._devices), function(device){
-    if(device.isOpen()){
-      return device.close();
-    }
+  var closingDevices = _.map(this.getOpenBoards(), function(device){
+    return device.close();
   });
 
   return when.settle(closingDevices);

--- a/lib/board.js
+++ b/lib/board.js
@@ -22,8 +22,16 @@ function removeBoard(type){
   delete this._boards[type];
 }
 
-function listPorts(){
-  return nodefn.call(Serialport.list);
+function listPorts(options){
+  var blacklist = _.get(options, 'blacklist') || [];
+  return nodefn.call(Serialport.list)
+    .then(function(portList){
+      return _.reject(portList, function(port){
+        return _.some(blacklist, function(black){
+          return black.test(port.comName);
+        });
+      });
+    });
 }
 
 function getBoard(options){
@@ -63,17 +71,10 @@ function scanBoards(options){
     targetTypes = _.keys(this._boards);
   }
 
-  //close open ports so they can be scanned
-  var closingDevices = _.map(_.values(this._devices), function(device){
-    if(device.isOpen()){
-      return device.close();
-    }
-  });
-
-  return when.settle(closingDevices)
+  return this.releaseAllBoards()
     .then(function(){
       self._devices = [];
-      return self.listPorts();
+      return self.listPorts(options);
     })
     .then(function(ports){
       var portList = _.pluck(ports, 'comName');
@@ -96,9 +97,27 @@ function scanBoards(options){
   });
 }
 
+function getOpenBoards(){
+  return _.filter(_.values(this._devices), function(device){
+    return device.isOpen();
+  });
+}
+
+function releaseAllBoards(){
+  var closingDevices = _.map(_.values(this._devices), function(device){
+    if(device.isOpen()){
+      return device.close();
+    }
+  });
+
+  return when.settle(closingDevices);
+}
+
 module.exports = {
   addBoard: addBoard,
+  releaseAllBoards: releaseAllBoards,
   getBoard: getBoard,
+  getOpenBoards: getOpenBoards,
   listPorts: listPorts,
   removeBoard: removeBoard,
   scanBoards: scanBoards


### PR DESCRIPTION
#### What's this PR do?
Adds an options field to `scanBoards` and `listPorts` that will allow for blacklisting ports. Also separates `releaseAllBoards` logic into a separate method.
#### Any background context you want to provide?
Any regexp in the `options.blacklist` array will be tested against the `comName` of the port.
#### What are the relevant tickets?
Refs parallaxinc/ChromeIDE/issues/116