### PR TITLE
Pass options into board scanning implementation, add new default values.

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -81,12 +81,12 @@ function scanBoards(options){
   return this.releaseAllBoards()
     .then(function(){
       self._devices = {};
-      return self.listPorts(options);
+      return self.listPorts(opts);
     })
     .then(function(ports){
       var portList = _.pluck(ports, 'comName');
       return when.reduce(targetBoards, function(boardList, board, ix){
-        return board.search(portList)
+        return board.search(portList, opts)
           .then(function(newBoards){
             _.forEach(newBoards, function(boardInfo){
               boardInfo.type = targetTypes[ix];

--- a/lib/board.js
+++ b/lib/board.js
@@ -60,7 +60,7 @@ function generateEmptyPortlist(portList){
       path: port,
       type: type,
       match: false,
-      data: null,
+      program: null,
       board: {
         path: port
       }

--- a/lib/board.js
+++ b/lib/board.js
@@ -59,6 +59,8 @@ function generateEmptyPortlist(portList){
       name: null,
       path: port,
       type: type,
+      match: false,
+      data: null,
       board: {
         path: port
       }


### PR DESCRIPTION
#### What's this PR do?
This PR passes options object into the board scan method within `irken.scanBoards()`, which allows for additional configuration to pass through to board-specific implementations. Also adds default values for new board fields introduced in irkenjs/bs2-serial/pull/12
#### Any background context you want to provide?
#### What are the relevant tickets?
Depends on irkenjs/bs2-serial/pull/12
parallaxinc/Parallax-IDE/issues/132
parallaxinc/Parallax-IDE/issues/164