### PR TITLE
Expose compile function

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -41,6 +41,12 @@ function listPorts(options){
     });
 }
 
+function compile(options){
+  var type = options.type || getFallbackType();
+  var Board = this._boards[type];
+  return Board.compile(options.source);
+}
+
 function getBoard(options){
   var uniqueName = generateUniqueName(options);
   var device = this._devices[uniqueName];
@@ -122,10 +128,11 @@ function releaseAllBoards(){
 
 module.exports = {
   addBoard: addBoard,
-  releaseAllBoards: releaseAllBoards,
+  compile: compile,
   getBoard: getBoard,
   getOpenBoards: getOpenBoards,
   listPorts: listPorts,
+  releaseAllBoards: releaseAllBoards,
   removeBoard: removeBoard,
   scanBoards: scanBoards
 };


### PR DESCRIPTION
#### What's this PR do?
This PR exposes a generic compile function within Irken, which can be used to generate a compiled result from a board implementation without knowing the internal structure of the target implementation.
#### Any background context you want to provide?
This is needed to provide syntax checking functionality without specifically referencing the target board implementation.
#### What are the relevant tickets?
parallaxinc/Parallax-IDE/issues/129