### PR TITLE
Remove serial-port dependency and refactor search to be board-independent

### DIFF
--- a/lib/board.js
+++ b/lib/board.js
@@ -2,8 +2,6 @@
 
 var _ = require('lodash');
 var when = require('when');
-var nodefn = require('when/node');
-var Serialport = require('browser-serialport');
 
 function getFallbackType(){
   //TODO eventually will be used to select a board type when one isn't detected.
@@ -20,25 +18,6 @@ function addBoard(type, Board){
 
 function removeBoard(type){
   delete this._boards[type];
-}
-
-function listPorts(options){
-  var reject = _.get(options, 'reject') || [];
-  var predicate = reject;
-  if(Array.isArray(reject)){
-    predicate = function(port){
-      return _.some(reject, function(entry){
-        if(typeof entry === 'string'){
-          return port.comName === entry;
-        }
-        return entry.test(port.comName);
-      });
-    };
-  }
-  return nodefn.call(Serialport.list)
-    .then(function(portList){
-      return _.reject(portList, predicate);
-    });
 }
 
 function compile(options){
@@ -58,22 +37,6 @@ function getBoard(options){
   return device;
 }
 
-function generateEmptyPortlist(portList){
-  var type = getFallbackType();
-  return _.map(portList, function(port){
-    return {
-      name: null,
-      path: port,
-      type: type,
-      match: false,
-      program: null,
-      board: {
-        path: port
-      }
-    };
-  });
-}
-
 function scanBoards(options){
   var self = this;
   var opts = options || {};
@@ -89,26 +52,15 @@ function scanBoards(options){
   return this.releaseAllBoards()
     .then(function(){
       self._devices = {};
-      return self.listPorts(opts);
-    })
-    .then(function(ports){
-      var portList = _.pluck(ports, 'comName');
       return when.reduce(targetBoards, function(boardList, board, ix){
-        return board.search(portList, opts)
+        return board.search(opts)
           .then(function(newBoards){
             _.forEach(newBoards, function(boardInfo){
               boardInfo.type = targetTypes[ix];
             });
             return boardList.concat(newBoards);
           });
-      }, [])
-      .then(function(boards){
-        var allPorts = generateEmptyPortlist(portList);
-        var emptyPorts = _.reject(allPorts, function(ep){
-          return _.find(boards, { path: ep.path });
-        });
-        return boards.concat(emptyPorts);
-      });
+      }, []);
   });
 }
 
@@ -131,7 +83,6 @@ module.exports = {
   compile: compile,
   getBoard: getBoard,
   getOpenBoards: getOpenBoards,
-  listPorts: listPorts,
   releaseAllBoards: releaseAllBoards,
   removeBoard: removeBoard,
   scanBoards: scanBoards

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "bach": "^0.4.1",
-    "browser-serialport": "^2.0.2",
     "dooomrdy": "0.0.1",
     "lodash": "^3.3.1",
     "pak": "^0.1.0",


### PR DESCRIPTION
#### What's this PR do?
This PR moves the listPorts part of the search implementation into the board interface itself. This allows for a more generic search implementation.
#### What are the relevant tickets?
Depends on irkenjs/bs2-serial/pull/20
Depends on irkenjs/bs2-serialport/pull/14